### PR TITLE
Support for JAVA_HOME, error msg when class not found. Fix "native method not found"

### DIFF
--- a/jvmgo/classpath/class_path.go
+++ b/jvmgo/classpath/class_path.go
@@ -2,13 +2,14 @@ package classpath
 
 import (
 	"errors"
-	"github.com/zxh0/jvm.go/jvmgo/jvm/options"
 	"path/filepath"
 	"strings"
+
+	"github.com/zxh0/jvm.go/jvmgo/jvm/options"
 )
 
 var (
-	absBootPath      = filepath.Join(options.AbsJavaHome, "lib") // jre/lib
+	absBootPath      = filepath.Join(options.AbsJavaHome, "jre/lib")
 	classNotFoundErr = errors.New("class not found!")
 )
 

--- a/jvmgo/jvm/jerrors/class_not_found.go
+++ b/jvmgo/jvm/jerrors/class_not_found.go
@@ -1,5 +1,9 @@
 package jerrors
 
+import (
+	"fmt"
+)
+
 type ClassNotFoundError struct {
 	name string
 }
@@ -9,5 +13,5 @@ func NewClassNotFoundError(name string) ClassNotFoundError {
 }
 
 func (self ClassNotFoundError) Error() string {
-	return self.name
+	return fmt.Sprintf("Class not found %v", self.name)
 }

--- a/jvmgo/jvm/options/options.go
+++ b/jvmgo/jvm/options/options.go
@@ -1,11 +1,12 @@
 package options
 
 import (
+	"os"
 	"path/filepath"
 )
 
 // todo
-const JavaHome = "./jre/"
+const JavaHome = "."
 
 var (
 	AbsJavaHome     string
@@ -14,7 +15,12 @@ var (
 )
 
 func init() {
-	if absJavaHome, err := filepath.Abs(JavaHome); err == nil {
+	jh := os.Getenv("JAVA_HOME")
+	if jh == "" {
+		jh = JavaHome
+	}
+
+	if absJavaHome, err := filepath.Abs(jh); err == nil {
 		AbsJavaHome = absJavaHome
 	} else {
 		panic(err)

--- a/jvmgo/native/java/lang/Class_static.go
+++ b/jvmgo/native/java/lang/Class_static.go
@@ -7,7 +7,7 @@ import (
 
 func init() {
 	_class(desiredAssertionStatus0, "desiredAssertionStatus0", "(Ljava/lang/Class;)Z")
-	_class(forName0, "forName0", "(Ljava/lang/String;ZLjava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/Class;")
+	_class(forName0, "forName0", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;")
 	_class(getPrimitiveClass, "getPrimitiveClass", "(Ljava/lang/String;)Ljava/lang/Class;")
 }
 


### PR DESCRIPTION
This PR has 2 things I did:
1. Make it read JAVA_HOME env variable and be able to run without having to drop the binary in java's installation.
2. Fix for the issue I ran into when run hello world.
> panic: native method not found: java/lang/Class~forName0~(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;
goroutine 1 [running]:
github.com/zxh0/jvm.go/jvmgo/jvm/interpreter._catchErr(0x18c20420)
/home/phaikawl/Dev/go/src/github.com/zxh0/jvm.go/jvmgo/jvm/interpreter/interpreter.go:101 +0x1b5
github.com/zxh0/jvm.go/jvmgo/jvm/rtda/class.findNativeMethod(0x1843afc0, 0x0, 0x0)
	/home/phaikawl/Dev/go/src/github.com/zxh0/jvm.go/jvmgo/jvm/rtda/class/native_method_registry.go:33 +0x162
github.com/zxh0/jvm.go/jvmgo/jvm/rtda/class.(*Method).NativeMethod(0x1843afc0, 0x0, 0x0)
	/home/phaikawl/Dev/go/src/github.com/zxh0/jvm.go/jvmgo/jvm/rtda/class/method.go:104 +0x3e
github.com/zxh0/jvm.go/jvmgo/jvm/instructions.(*invoke_native).Execute(0x8292a00, 0x18fd90e0)
	/home/phaikawl/Dev/go/src/github.com/zxh0/jvm.go/jvmgo/jvm/instructions/invoke_native.go:9 

I just changed the descriptor to match and it works, not sure if what caused was a typo or it's some platform difference issue.

I'm wondering however, why is it necessary to put descriptor into the registry's map key? Can different descriptors corresponds to different methods or things? (please forgive me I don't know anything about java).
