### PR TITLE
fixed: panic when `GetFileAttributesEx` error

### DIFF
--- a/jvmgo/classpath/entry_wildcard.go
+++ b/jvmgo/classpath/entry_wildcard.go
@@ -15,6 +15,9 @@ func newWildcardEntry(path string) *WildcardEntry {
 	entry := &WildcardEntry{}
 
 	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() && path != baseDir {
 			return filepath.SkipDir
 		}


### PR DESCRIPTION
If there was a problem walking to the file or directory named by path, the incoming error should be checked, and return it to prevent flow logic panic.