### PR TITLE
fix retrieve interface{} value

### DIFF
--- a/jvmgo/jutil/atomic.go
+++ b/jvmgo/jutil/atomic.go
@@ -2,23 +2,20 @@ package jutil
 
 import (
 	"sync/atomic"
-	"unsafe"
 )
 
-// copied from go/src/sync/atomic/value.go
-type ifaceWords struct {
-	typ  unsafe.Pointer
-	data unsafe.Pointer
-}
-
 func CasInt32(any interface{}, old, _new int32) bool {
-	ifws := (*ifaceWords)(unsafe.Pointer(&any))
-	addr := (*int32)(ifws.data)
-	return atomic.CompareAndSwapInt32(addr, old, _new)
+	addr,ok:=any.(int32)
+	if ok{
+		return atomic.CompareAndSwapInt32(&addr, old, _new)
+	}
+	return false
 }
 
 func CasInt64(any interface{}, old, _new int64) bool {
-	ifws := (*ifaceWords)(unsafe.Pointer(&any))
-	addr := (*int64)(ifws.data)
-	return atomic.CompareAndSwapInt64(addr, old, _new)
+	addr,ok:=any.(int64)
+	if ok{
+		return atomic.CompareAndSwapInt64(&addr, old, _new)
+	}
+	return false
 }


### PR DESCRIPTION
老代码在go1.9版本无法正常运行