### PR TITLE
Fixed method can't be found issue for FileDescriptor and Win32ErrorMode

### DIFF
--- a/jvmgo/native/java/io/FileOutputStream.go
+++ b/jvmgo/native/java/io/FileOutputStream.go
@@ -35,6 +35,8 @@ func writeBytes(frame *rtda.Frame) {
 			fdObj.SetExtra(os.Stdout)
 		case 2:
 			fdObj.SetExtra(os.Stderr)
+		default:
+			fdObj.SetExtra(os.Stdout)
 		}
 	}
 	goFile := fdObj.Extra().(*os.File)

--- a/jvmgo/native/native_methods.go
+++ b/jvmgo/native/native_methods.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/zxh0/jvm.go/jvmgo/native/java/util/jar"
 	_ "github.com/zxh0/jvm.go/jvmgo/native/java/util/zip"
 	_ "github.com/zxh0/jvm.go/jvmgo/native/sun/awt"
+	_ "github.com/zxh0/jvm.go/jvmgo/native/sun/io"
 	_ "github.com/zxh0/jvm.go/jvmgo/native/sun/java2d/opengl"
 	_ "github.com/zxh0/jvm.go/jvmgo/native/sun/management"
 	_ "github.com/zxh0/jvm.go/jvmgo/native/sun/misc"

--- a/jvmgo/native/sun/io/Win32ErrorMode.go
+++ b/jvmgo/native/sun/io/Win32ErrorMode.go
@@ -6,13 +6,13 @@ import (
 )
 
 func init() {
-	_fd(set, "set", "(I)J")
+	_fd(setErrorMode, "setErrorMode", "(J)J")
 }
 
 func _fd(method func(frame *rtda.Frame), name, desc string) {
-	heap.RegisterNativeMethod("java/io/FileDescriptor", name, desc, method)
+	heap.RegisterNativeMethod("sun/io/Win32ErrorMode", name, desc, method)
 }
 
-func set(frame *rtda.Frame)  {
+func setErrorMode(frame *rtda.Frame)  {
 	frame.OperandStack().PushLong(0)
 }


### PR DESCRIPTION
Execute HelloWorld.java on Windows 10 with Oracle JDK8 keeps having an issue with classes `FileDescriptor` and `Win32ErrorMode`

```
public class HelloWorld {
    
    public static void main(String[] args) {
        System.out.println("Hello, world!");
    }
    
}
```

This PR should be able to fix this issue https://github.com/zxh0/jvm.go/issues/43